### PR TITLE
Fix for .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "dwm1001_ros2"]
 	path = dwm1001_ros2
 	url = https://github.com/the-hive-lab/dwm1001_ros2.git
+[submodule "dwm1001_ros2_2"]
+	path = ros_ws/src/dwm1001_ros2
+	url = https://github.com/the-hive-lab/dwm1001_ros2.git
+	


### PR DESCRIPTION
Was having issues with the dwm1001_ros2 submodules.

Currently, this package is in the repo twice, could likely remove one.

Was getting the following error when running git submodule update --init --recursive 
fatal: No url found for submodule path 'ros_ws/src/dwm1001_ros2' in .gitmodules

This commit fixes above error.